### PR TITLE
Remove extern blocks to fix debug problems

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,12 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.10.0"),
   ],
   targets: [
-    .target(name: "cmark-gfm"),
+    .target(
+      name: "cmark-gfm",
+      linkerSettings: [
+        .linkedLibrary("c++"),
+      ]
+    ),
     .target(
       name: "MarkdownUI",
       dependencies: [

--- a/Sources/cmark-gfm/include/cmark-gfm-core-extensions.h
+++ b/Sources/cmark-gfm/include/cmark-gfm-core-extensions.h
@@ -1,10 +1,6 @@
 #ifndef CMARK_GFM_CORE_EXTENSIONS_H
 #define CMARK_GFM_CORE_EXTENSIONS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "cmark-gfm-extension_api.h"
 #include "cmark-gfm-extensions_export.h"
 #include "config.h" // for bool
@@ -46,9 +42,5 @@ bool cmark_gfm_extensions_get_tasklist_item_checked(cmark_node *node);
  */
 CMARK_GFM_EXTENSIONS_EXPORT
 int cmark_gfm_extensions_set_tasklist_item_checked(cmark_node *node, bool is_checked);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/Sources/cmark-gfm/include/cmark-gfm-extension_api.h
+++ b/Sources/cmark-gfm/include/cmark-gfm-extension_api.h
@@ -1,10 +1,6 @@
 #ifndef CMARK_GFM_EXTENSION_API_H
 #define CMARK_GFM_EXTENSION_API_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "cmark-gfm.h"
 
 struct cmark_renderer;
@@ -728,9 +724,5 @@ void cmark_arena_push(void);
 
 CMARK_GFM_EXPORT
 int cmark_arena_pop(void);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/Sources/cmark-gfm/include/cmark-gfm.h
+++ b/Sources/cmark-gfm/include/cmark-gfm.h
@@ -6,10 +6,6 @@
 #include "cmark-gfm_export.h"
 #include "cmark-gfm_version.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /** # NAME
  *
  * **cmark-gfm** - CommonMark parsing, manipulating, and rendering
@@ -809,9 +805,5 @@ const char *cmark_version_string(void);
 #endif
 
 typedef int32_t bufsize_t;
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/Sources/cmark-gfm/include/cmark_ctype.h
+++ b/Sources/cmark-gfm/include/cmark_ctype.h
@@ -1,10 +1,6 @@
 #ifndef CMARK_CMARK_CTYPE_H
 #define CMARK_CMARK_CTYPE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "cmark-gfm_export.h"
 
 /** Locale-independent versions of functions from ctype.h.
@@ -25,9 +21,5 @@ int cmark_isdigit(char c);
 
 CMARK_GFM_EXPORT
 int cmark_isalpha(char c);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/Sources/cmark-gfm/include/houdini.h
+++ b/Sources/cmark-gfm/include/houdini.h
@@ -1,10 +1,6 @@
 #ifndef CMARK_HOUDINI_H
 #define CMARK_HOUDINI_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include "config.h"
 #include "buffer.h"
@@ -49,9 +45,5 @@ void houdini_unescape_html_f(cmark_strbuf *ob, const uint8_t *src,
 CMARK_GFM_EXPORT
 int houdini_escape_href(cmark_strbuf *ob, const uint8_t *src,
                                bufsize_t size);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/Sources/cmark-gfm/include/inlines.h
+++ b/Sources/cmark-gfm/include/inlines.h
@@ -1,10 +1,6 @@
 #ifndef CMARK_INLINES_H
 #define CMARK_INLINES_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "references.h"
 
 cmark_chunk cmark_clean_url(cmark_mem *mem, cmark_chunk *url);
@@ -21,9 +17,5 @@ bufsize_t cmark_parse_reference_inline(cmark_mem *mem, cmark_chunk *input,
 
 void cmark_inlines_add_special_character(unsigned char c, bool emphasis);
 void cmark_inlines_remove_special_character(unsigned char c, bool emphasis);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/Sources/cmark-gfm/include/iterator.h
+++ b/Sources/cmark-gfm/include/iterator.h
@@ -1,10 +1,6 @@
 #ifndef CMARK_ITERATOR_H
 #define CMARK_ITERATOR_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "cmark-gfm.h"
 
 typedef struct {
@@ -18,9 +14,5 @@ struct cmark_iter {
   cmark_iter_state cur;
   cmark_iter_state next;
 };
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/Sources/cmark-gfm/include/node.h
+++ b/Sources/cmark-gfm/include/node.h
@@ -1,10 +1,6 @@
 #ifndef CMARK_NODE_H
 #define CMARK_NODE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdio.h>
 #include <stdint.h>
 
@@ -117,9 +113,5 @@ static CMARK_INLINE bool CMARK_NODE_INLINE_P(cmark_node *node) {
 }
 
 CMARK_GFM_EXPORT bool cmark_node_can_contain_type(cmark_node *node, cmark_node_type child_type);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/Sources/cmark-gfm/include/plugin.h
+++ b/Sources/cmark-gfm/include/plugin.h
@@ -1,10 +1,6 @@
 #ifndef CMARK_PLUGIN_H
 #define CMARK_PLUGIN_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "cmark-gfm.h"
 #include "cmark-gfm-extension_api.h"
 
@@ -26,9 +22,5 @@ cmark_plugin_new(void);
 
 void
 cmark_plugin_free(cmark_plugin *plugin);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/Sources/cmark-gfm/include/references.h
+++ b/Sources/cmark-gfm/include/references.h
@@ -3,10 +3,6 @@
 
 #include "map.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 struct cmark_reference {
   cmark_map_entry entry;
   cmark_chunk url;
@@ -18,9 +14,5 @@ typedef struct cmark_reference cmark_reference;
 void cmark_reference_create(cmark_map *map, cmark_chunk *label,
                             cmark_chunk *url, cmark_chunk *title);
 cmark_map *cmark_reference_map_new(cmark_mem *mem);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/Sources/cmark-gfm/include/registry.h
+++ b/Sources/cmark-gfm/include/registry.h
@@ -1,10 +1,6 @@
 #ifndef CMARK_REGISTRY_H
 #define CMARK_REGISTRY_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "cmark-gfm.h"
 #include "plugin.h"
 
@@ -16,9 +12,5 @@ void cmark_release_plugins(void);
 
 CMARK_GFM_EXPORT
 cmark_llist *cmark_list_syntax_extensions(cmark_mem *mem);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/Sources/cmark-gfm/include/render.h
+++ b/Sources/cmark-gfm/include/render.h
@@ -1,10 +1,6 @@
 #ifndef CMARK_RENDER_H
 #define CMARK_RENDER_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdlib.h>
 #include "buffer.h"
 #include "chunk.h"
@@ -54,9 +50,5 @@ char *cmark_render(cmark_mem *mem, cmark_node *root, int options, int width,
                    int (*render_node)(cmark_renderer *renderer,
                                       cmark_node *node,
                                       cmark_event_type ev_type, int options));
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif


### PR DESCRIPTION
We get errors (see below) when trying to debug. This appears to be the problem. 

**References**

- https://forums.swift.org/t/import-of-c-module-appears-within-extern-c-language-linkage-specification/65606/2


**The Errors**

```
(lldb) po layers[0].children
error: couldn't IRGen expression: Clang importer error
error: ~/.../SourcePackages/checkouts/swift-markdown-ui/Sources/cmark-gfm/include/cmark-gfm-core-extensions.h:8:1: error: import of C++ module 'cmark_gfm' appears within extern "C" language linkage specification
#include "cmark-gfm-extension_api.h"
^
error: ~/.../SourcePackages/checkouts/swift-markdown-ui/Sources/cmark-gfm/include/cmark-gfm-extension_api.h:8:1: error: import of C++ module 'cmark_gfm' appears within extern "C" language linkage specification
#include "cmark-gfm.h"
```